### PR TITLE
fix: define error callback for fs.unlink()

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -54,8 +54,8 @@ exports.execute = function(file, bin, func, args){
 
                 var data = JSON.parse(fs.readFileSync(tmpResult));
 
-                fs.unlinkSync(tmpParam);
-                fs.unlinkSync(tmpResult);
+                fs.unlinkSync(tmpParam, function(err){console.error(err)});
+                fs.unlinkSync(tmpResult, function(err){console.error(err)});
 
                 user_fn_cb(false, data.result, data.output, data.printed);
             });


### PR DESCRIPTION
The callback was missing and threw an error due to it. We should set it and catch the errors.